### PR TITLE
feat: add shouldCount option and bump loader to v6

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "dependencies": {
     "@microsoft/api-extractor": "^7.56.3",
     "@rslib/core": "^0.19.6",
-    "@woovi/graphql-mongoose-loader": "5.1.3",
+    "@woovi/graphql-mongoose-loader": "6.0.0",
     "graphql-relay": "^0.10.2",
     "mongoose": "^9.2.1",
     "vitest": "^4.0.18"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@woovi/graphql-mongo-helpers",
   "description": "Mongo helpers to be used when building a GraphQL API",
-  "version": "3.0.6",
+  "version": "4.0.0",
   "author": {
     "name": "Entria",
     "email": "dev@woovi.com",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,8 +15,8 @@ importers:
         specifier: ^0.19.6
         version: 0.19.6(@microsoft/api-extractor@7.56.3(@types/node@25.0.9))(typescript@5.9.3)
       '@woovi/graphql-mongoose-loader':
-        specifier: 5.1.3
-        version: 5.1.3(graphql-relay@0.10.2(graphql@16.12.0))(graphql@16.12.0)(mongoose@9.2.1)
+        specifier: 6.0.0
+        version: 6.0.0(graphql-relay@0.10.2(graphql@16.12.0))(graphql@16.12.0)(mongoose@9.2.1)
       graphql-relay:
         specifier: ^0.10.2
         version: 0.10.2(graphql@16.12.0)
@@ -474,9 +474,6 @@ packages:
   '@module-federation/webpack-bundler-runtime@0.22.0':
     resolution: {integrity: sha512-aM8gCqXu+/4wBmJtVeMeeMN5guw3chf+2i6HajKtQv7SJfxV/f4IyNQJUeUQu9HfiAZHjqtMV5Lvq/Lvh8LdyA==}
 
-  '@mongodb-js/saslprep@1.4.5':
-    resolution: {integrity: sha512-k64Lbyb7ycCSXHSLzxVdb2xsKGPMvYZfCICXvDsI8Z65CeWQzTEKS4YmGbnqw+U9RBvLPTsB6UCmwkgsDTGWIw==}
-
   '@mongodb-js/saslprep@1.4.6':
     resolution: {integrity: sha512-y+x3H1xBZd38n10NZF/rEBlvDOOMQ6LKUTHqr8R9VkJ+mmQOYtJFxIlkkK8fZrtOiL6VixbOBWMbZGBdal3Z1g==}
 
@@ -861,8 +858,8 @@ packages:
   '@vitest/utils@4.0.18':
     resolution: {integrity: sha512-msMRKLMVLWygpK3u2Hybgi4MNjcYJvwTb0Ru09+fOyCXIgT5raYP041DRRdiJiI3k/2U6SEbAETB3YtBrUkCFA==}
 
-  '@woovi/graphql-mongoose-loader@5.1.3':
-    resolution: {integrity: sha512-rGOCg/CezD+q+j5dvLc8XqwXtlH5Y06kWa31pdD2OuKPDRxfiGGXxRlyvDAM2u9Dy/W8rKk5ldsIzLJDE0NVCQ==}
+  '@woovi/graphql-mongoose-loader@6.0.0':
+    resolution: {integrity: sha512-ohjK8iFnyfX/QT3dVVxh4g8MzB6uWA6iqCwB0CiC4SDS2mXgWn0kKt1HPBaU+cBvfGjqnWa3m6rAtObCuNCm7A==}
     peerDependencies:
       graphql: '*'
       graphql-relay: '*'
@@ -1822,11 +1819,6 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
 
-  semver@7.7.3:
-    resolution: {integrity: sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==}
-    engines: {node: '>=10'}
-    hasBin: true
-
   semver@7.7.4:
     resolution: {integrity: sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==}
     engines: {node: '>=10'}
@@ -2509,10 +2501,6 @@ snapshots:
       '@module-federation/runtime': 0.22.0
       '@module-federation/sdk': 0.22.0
 
-  '@mongodb-js/saslprep@1.4.5':
-    dependencies:
-      sparse-bitfield: 3.0.3
-
   '@mongodb-js/saslprep@1.4.6':
     dependencies:
       sparse-bitfield: 3.0.3
@@ -2879,7 +2867,7 @@ snapshots:
       '@vitest/pretty-format': 4.0.18
       tinyrainbow: 3.0.3
 
-  '@woovi/graphql-mongoose-loader@5.1.3(graphql-relay@0.10.2(graphql@16.12.0))(graphql@16.12.0)(mongoose@9.2.1)':
+  '@woovi/graphql-mongoose-loader@6.0.0(graphql-relay@0.10.2(graphql@16.12.0))(graphql@16.12.0)(mongoose@9.2.1)':
     dependencies:
       graphql: 16.12.0
       graphql-relay: 0.10.2(graphql@16.12.0)
@@ -3551,7 +3539,7 @@ snapshots:
       https-proxy-agent: 7.0.6
       mongodb: 6.21.0
       new-find-package-json: 2.0.0
-      semver: 7.7.3
+      semver: 7.7.4
       tar-stream: 3.1.7
       tslib: 2.8.1
       yauzl: 3.2.0
@@ -3585,7 +3573,7 @@ snapshots:
 
   mongodb@6.21.0:
     dependencies:
-      '@mongodb-js/saslprep': 1.4.5
+      '@mongodb-js/saslprep': 1.4.6
       bson: 6.10.4
       mongodb-connection-string-url: 3.0.2
 
@@ -3785,8 +3773,6 @@ snapshots:
   semver@7.5.4:
     dependencies:
       lru-cache: 6.0.0
-
-  semver@7.7.3: {}
 
   semver@7.7.4: {}
 

--- a/src/__tests__/createLoader.spec.ts
+++ b/src/__tests__/createLoader.spec.ts
@@ -1,0 +1,114 @@
+import { vi, it, expect, describe, beforeEach } from 'vitest';
+import { connectionFromMongoCursor, connectionFromMongoAggregate } from '@woovi/graphql-mongoose-loader';
+
+import { createLoader } from '../createLoader';
+
+vi.mock('@woovi/graphql-mongoose-loader', () => ({
+  mongooseLoader: vi.fn().mockResolvedValue([]),
+  connectionFromMongoCursor: vi.fn().mockResolvedValue({
+    edges: [],
+    count: null,
+    pageInfo: { hasNextPage: false, hasPreviousPage: false },
+  }),
+  connectionFromMongoAggregate: vi.fn().mockResolvedValue({
+    edges: [],
+    count: null,
+    pageInfo: { hasNextPage: false, hasPreviousPage: false },
+  }),
+}));
+
+const mockModel = {
+  find: vi.fn().mockReturnValue({
+    sort: vi.fn().mockReturnThis(),
+  }),
+  aggregate: vi.fn().mockReturnValue({
+    pipeline: vi.fn().mockReturnValue([]),
+  }),
+  collection: { collectionName: 'test' },
+} as any;
+
+const loaderName = 'TestLoader' as const;
+
+const createContext = () => ({
+  dataloaders: {
+    [loaderName]: {
+      load: vi.fn(),
+      clear: vi.fn(),
+      prime: vi.fn(),
+    },
+  },
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('createLoader shouldCount', () => {
+  it('should default shouldCount to false for cursor-based loader', async () => {
+    const { loadAll } = createLoader({
+      model: mockModel,
+      loaderName,
+    });
+
+    const context = createContext();
+    await loadAll(context, { first: 10, filters: null });
+
+    expect(connectionFromMongoCursor).toHaveBeenCalledWith(
+      expect.objectContaining({
+        shouldCount: false,
+      }),
+    );
+  });
+
+  it('should pass shouldCount=true for cursor-based loader when configured', async () => {
+    const { loadAll } = createLoader({
+      model: mockModel,
+      loaderName,
+      shouldCount: true,
+    });
+
+    const context = createContext();
+    await loadAll(context, { first: 10, filters: null });
+
+    expect(connectionFromMongoCursor).toHaveBeenCalledWith(
+      expect.objectContaining({
+        shouldCount: true,
+      }),
+    );
+  });
+
+  it('should default shouldCount to false for aggregate-based loader', async () => {
+    const { loadAll } = createLoader({
+      model: mockModel,
+      loaderName,
+      isAggregate: true,
+    });
+
+    const context = createContext();
+    await loadAll(context, { first: 10, filters: null });
+
+    expect(connectionFromMongoAggregate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        shouldCount: false,
+      }),
+    );
+  });
+
+  it('should pass shouldCount=true for aggregate-based loader when configured', async () => {
+    const { loadAll } = createLoader({
+      model: mockModel,
+      loaderName,
+      isAggregate: true,
+      shouldCount: true,
+    });
+
+    const context = createContext();
+    await loadAll(context, { first: 10, filters: null });
+
+    expect(connectionFromMongoAggregate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        shouldCount: true,
+      }),
+    );
+  });
+});

--- a/src/__tests__/withConnectionAggregate.spec.ts
+++ b/src/__tests__/withConnectionAggregate.spec.ts
@@ -1,0 +1,73 @@
+import { vi, it, expect, describe, beforeEach } from 'vitest';
+import { connectionFromMongoAggregate } from '@woovi/graphql-mongoose-loader';
+
+import { withConnectionAggregate } from '../withConnectionAggregate';
+
+vi.mock('@woovi/graphql-mongoose-loader', () => ({
+  connectionFromMongoAggregate: vi.fn().mockResolvedValue({
+    edges: [],
+    count: null,
+    pageInfo: { hasNextPage: false, hasPreviousPage: false },
+  }),
+}));
+
+const mockModel = {
+  aggregate: vi.fn().mockReturnValue({
+    pipeline: vi.fn().mockReturnValue([]),
+  }),
+} as any;
+
+const mockLoader = vi.fn();
+const mockCondFn = vi.fn().mockReturnValue({
+  defaultConditions: { removedAt: null },
+  builtMongoConditions: { conditions: {}, pipeline: [] },
+});
+const context = { dataloaders: {} };
+const args = { first: 10 };
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockCondFn.mockReturnValue({
+    defaultConditions: { removedAt: null },
+    builtMongoConditions: { conditions: {}, pipeline: [] },
+  });
+});
+
+describe('withConnectionAggregate', () => {
+  it('should pass shouldCount=false by default', async () => {
+    const loadAll = withConnectionAggregate(mockModel, mockLoader, mockCondFn);
+
+    await loadAll(context, args);
+
+    expect(connectionFromMongoAggregate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        shouldCount: false,
+      }),
+    );
+  });
+
+  it('should pass shouldCount=true when configured', async () => {
+    const loadAll = withConnectionAggregate(mockModel, mockLoader, mockCondFn, { shouldCount: true });
+
+    await loadAll(context, args);
+
+    expect(connectionFromMongoAggregate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        shouldCount: true,
+      }),
+    );
+  });
+
+  it('should forward context and args to connectionFromMongoAggregate', async () => {
+    const loadAll = withConnectionAggregate(mockModel, mockLoader, mockCondFn);
+
+    await loadAll(context, args);
+
+    expect(connectionFromMongoAggregate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        context,
+        args,
+      }),
+    );
+  });
+});

--- a/src/__tests__/withConnectionCursor.spec.ts
+++ b/src/__tests__/withConnectionCursor.spec.ts
@@ -1,0 +1,67 @@
+import { vi, it, expect, describe, beforeEach } from 'vitest';
+import { connectionFromMongoCursor } from '@woovi/graphql-mongoose-loader';
+
+import { withConnectionCursor } from '../withConnectionCursor';
+
+vi.mock('@woovi/graphql-mongoose-loader', () => ({
+  connectionFromMongoCursor: vi.fn().mockResolvedValue({
+    edges: [],
+    count: null,
+    pageInfo: { hasNextPage: false, hasPreviousPage: false },
+  }),
+}));
+
+const mockModel = {
+  find: vi.fn().mockReturnValue({
+    sort: vi.fn().mockReturnThis(),
+  }),
+} as any;
+
+const mockLoader = vi.fn();
+const mockCondFn = vi.fn().mockReturnValue({ conditions: { removedAt: null }, sort: { createdAt: -1 } });
+const context = { dataloaders: {} };
+const args = { first: 10 };
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockCondFn.mockReturnValue({ conditions: { removedAt: null }, sort: { createdAt: -1 } });
+});
+
+describe('withConnectionCursor', () => {
+  it('should pass shouldCount=false by default', async () => {
+    const loadAll = withConnectionCursor(mockModel, mockLoader, mockCondFn);
+
+    await loadAll(context, args);
+
+    expect(connectionFromMongoCursor).toHaveBeenCalledWith(
+      expect.objectContaining({
+        shouldCount: false,
+      }),
+    );
+  });
+
+  it('should pass shouldCount=true when configured', async () => {
+    const loadAll = withConnectionCursor(mockModel, mockLoader, mockCondFn, { shouldCount: true });
+
+    await loadAll(context, args);
+
+    expect(connectionFromMongoCursor).toHaveBeenCalledWith(
+      expect.objectContaining({
+        shouldCount: true,
+      }),
+    );
+  });
+
+  it('should forward context and args to connectionFromMongoCursor', async () => {
+    const loadAll = withConnectionCursor(mockModel, mockLoader, mockCondFn);
+
+    await loadAll(context, args);
+
+    expect(connectionFromMongoCursor).toHaveBeenCalledWith(
+      expect.objectContaining({
+        context,
+        args,
+      }),
+    );
+  });
+});

--- a/src/createLoader.ts
+++ b/src/createLoader.ts
@@ -28,6 +28,7 @@ export type CreateLoaderArgs<
   loaderName: LoaderName;
   filterMapping?: object;
   isAggregate?: boolean;
+  shouldCount?: boolean;
   shouldValidateContextUser?: boolean;
   defaultFilters?: object | filtersConditionsOrSortFn<Context>;
   defaultConditions?: object | filtersConditionsOrSortFn<Context>;
@@ -52,6 +53,7 @@ export const createLoader = <
   loaderName,
   filterMapping = {},
   isAggregate = false,
+  shouldCount = false,
   shouldValidateContextUser = false,
   defaultFilters = {},
   defaultConditions = {},
@@ -142,7 +144,7 @@ export const createLoader = <
         defaultConditions: mongoDefaultConditions,
         builtMongoConditions,
       };
-    })
+    }, { shouldCount })
     : withConnectionCursor(model, load, (context: Context, args: FilteredConnectionArguments) => {
       const { conditions, mongoDefaultSort } = buildFiltersConditionsAndSort(context, args);
 
@@ -150,7 +152,7 @@ export const createLoader = <
         conditions,
         sort: mongoDefaultSort,
       };
-    });
+    }, { shouldCount });
 
   return {
     Wrapper: Wrapper as {

--- a/src/withConnectionAggregate.ts
+++ b/src/withConnectionAggregate.ts
@@ -12,6 +12,7 @@ export const withConnectionAggregate =
     model: Model<any>,
     loader: LoaderFn<Context>,
     condFn: (...p: any[]) => WithConnectionAggregateConditions,
+    { shouldCount = false }: { shouldCount?: boolean } = {},
   ) =>
   (...params: any[]) => {
     const { defaultConditions = {}, builtMongoConditions } = condFn(...params);
@@ -27,5 +28,6 @@ export const withConnectionAggregate =
       context,
       args,
       loader: loader as any,
+      shouldCount,
     });
   };

--- a/src/withConnectionCursor.ts
+++ b/src/withConnectionCursor.ts
@@ -7,6 +7,7 @@ export const withConnectionCursor = <Context extends object>(
   model: Model<any>,
   loader: LoaderFn<Context>,
   condFn: (...p: any[]) => { conditions?: object; sort?: object },
+  { shouldCount = false }: { shouldCount?: boolean } = {},
 ) => (...params: any[]) => {
   const { conditions = {}, sort = {} } = condFn(...params);
 
@@ -20,5 +21,6 @@ export const withConnectionCursor = <Context extends object>(
     context,
     args,
     loader: loader as any,
+    shouldCount,
   });
 };


### PR DESCRIPTION
## Summary
- Bump `@woovi/graphql-mongoose-loader` to v6 which adds the `shouldCount` flag
- Expose `shouldCount?: boolean` (default `false`) through `createLoader`, `withConnectionCursor`, and `withConnectionAggregate`
- Count queries (`countDocuments` / aggregate `$count`) are now skipped by default, eliminating an expensive DB round-trip per connection query

## Test plan
- [x] All 28 existing vitest tests pass
- [ ] Verify downstream consumers (`woovi-webhook`) work correctly with `count: null`

🤖 Generated with [Claude Code](https://claude.com/claude-code)