### PR TITLE
feat: add graphql order and enum helpers from monorepo @woovi/graphql

### DIFF
--- a/src/__tests__/order.spec.ts
+++ b/src/__tests__/order.spec.ts
@@ -1,0 +1,62 @@
+import { it, expect } from 'vitest';
+import { GraphQLEnumType } from 'graphql';
+
+import { conditionId } from '../conditionId';
+import { buildSortFromOrderByArg } from '../buildSortFromOrderByArg';
+import { orderByFilterField } from '../orderByFilterField';
+import { orderInput } from '../orderInput';
+import { FILTER_CONDITION_TYPE } from '../constants';
+
+it('should return an empty array for an invalid ObjectId', () => {
+  expect(conditionId('not-a-valid-id')).toEqual([]);
+  expect(conditionId(null)).toEqual([]);
+});
+
+it('should return an _id condition for a valid ObjectId', () => {
+  const id = '507f1f77bcf86cd799439011';
+  const condition = conditionId(id);
+  expect(condition).toHaveLength(1);
+  expect(condition[0]._id.toString()).toBe(id);
+});
+
+it('should build a sort object from the orderBy arg', () => {
+  const sort = buildSortFromOrderByArg([
+    { sort: 'createdAt', direction: -1 },
+    { sort: 'name', direction: 1 },
+  ]);
+  expect(sort).toEqual({
+    createdAt: -1,
+    name: 1,
+  });
+});
+
+it('should expose an AGGREGATE_PIPELINE orderBy filter that emits a $sort stage', () => {
+  expect(orderByFilterField.orderBy.type).toBe(
+    FILTER_CONDITION_TYPE.AGGREGATE_PIPELINE,
+  );
+  const pipeline = orderByFilterField.orderBy.pipeline([
+    { sort: 'createdAt', direction: -1 },
+  ]);
+  expect(pipeline).toEqual([
+    {
+      $sort: {
+        createdAt: -1,
+      },
+    },
+  ]);
+});
+
+it('should build an input object type with sort and direction fields', () => {
+  const sortEnum = new GraphQLEnumType({
+    name: 'ExampleSortEnum',
+    values: {
+      createdAt: { value: 'createdAt' },
+    },
+  });
+  const input = orderInput('ExampleOrderInput', sortEnum);
+  expect(input.name).toBe('ExampleOrderInput');
+  const fields = input.getFields();
+  expect(Object.keys(fields).sort()).toEqual(['direction', 'sort']);
+  expect(fields.sort.type.toString()).toBe('ExampleSortEnum!');
+  expect(fields.direction.type.toString()).toBe('DirectionEnum!');
+});

--- a/src/buildSortFromOrderByArg.ts
+++ b/src/buildSortFromOrderByArg.ts
@@ -1,0 +1,18 @@
+export type DIRECTION = 1 | -1;
+
+export type OrderByArg<SortT> = {
+  sort: SortT;
+  direction: DIRECTION;
+};
+
+export function buildSortFromOrderByArg<TSort extends string>(
+  orderByArg: OrderByArg<TSort>[],
+): { [key: string]: 1 | -1 } {
+  return orderByArg.reduce(
+    (acc, item) => ({
+      ...acc,
+      [item.sort]: item.direction,
+    }),
+    {},
+  );
+}

--- a/src/conditionId.ts
+++ b/src/conditionId.ts
@@ -1,0 +1,13 @@
+import { Types } from 'mongoose';
+
+export const conditionId = (id: string | null) => {
+  if (!id || !Types.ObjectId.isValid(id)) {
+    return [];
+  }
+
+  return [
+    {
+      _id: new Types.ObjectId(id),
+    },
+  ];
+};

--- a/src/graphqlEnumBuilder.ts
+++ b/src/graphqlEnumBuilder.ts
@@ -1,0 +1,37 @@
+import { GraphQLEnumType } from 'graphql';
+
+type EnumObject = {
+  [index: string]: string;
+};
+
+type EnumObjectResult = {
+  [index: string]: {
+    value: string;
+  };
+};
+export const enumBuilderValues = <T extends EnumObject = EnumObject>(
+  constants: T,
+): EnumObjectResult =>
+  Object.keys(constants).reduce(
+    (prev, curr) => ({
+      ...prev,
+      [curr]: {
+        value: constants[curr],
+      },
+    }),
+    {},
+  );
+/*
+export const GenderEnumType = new GraphQLEnumType({
+  name: 'GenderEnumType',
+  values: enumBuilderValues(GENDER),
+});
+*/
+export const graphqlEnumBuilder = <T extends EnumObject = EnumObject>(
+  name: string,
+  values: T,
+) =>
+  new GraphQLEnumType({
+    name,
+    values: enumBuilderValues(values),
+  });

--- a/src/index.ts
+++ b/src/index.ts
@@ -23,6 +23,16 @@ export { errorField, successField } from './statusFields';
 export { withFilter, type ArgsWithFilter } from './withFilter';
 export { NullConnection, type NullConnectionType } from './NullConnection';
 export { mongooseIDResolver } from './mongooseIDResolver.ts'
+export { conditionId } from './conditionId';
+export { enumBuilderValues, graphqlEnumBuilder } from './graphqlEnumBuilder';
+export {
+  buildSortFromOrderByArg,
+  type DIRECTION,
+  type OrderByArg,
+} from './buildSortFromOrderByArg';
+export { orderByField } from './orderByField';
+export { orderByFilterField } from './orderByFilterField';
+export { orderInput } from './orderInput';
 export {
   getLoader,
   getType,

--- a/src/orderByField.ts
+++ b/src/orderByField.ts
@@ -1,0 +1,8 @@
+import type { GraphQLInputObjectType } from 'graphql';
+import { GraphQLList, GraphQLNonNull } from 'graphql';
+
+export const orderByField = (orderInput: GraphQLInputObjectType) => ({
+  orderBy: {
+    type: new GraphQLList(new GraphQLNonNull(orderInput)),
+  },
+});

--- a/src/orderByFilterField.ts
+++ b/src/orderByFilterField.ts
@@ -1,0 +1,16 @@
+import {
+  buildSortFromOrderByArg,
+  type OrderByArg,
+} from './buildSortFromOrderByArg';
+import { FILTER_CONDITION_TYPE } from './constants';
+
+export const orderByFilterField = {
+  orderBy: {
+    type: FILTER_CONDITION_TYPE.AGGREGATE_PIPELINE,
+    pipeline: (value: OrderByArg<string>[]) => [
+      {
+        $sort: buildSortFromOrderByArg(value),
+      },
+    ],
+  },
+};

--- a/src/orderInput.ts
+++ b/src/orderInput.ts
@@ -1,0 +1,17 @@
+import type { GraphQLEnumType } from 'graphql';
+import { GraphQLInputObjectType, GraphQLNonNull } from 'graphql';
+
+import { DirectionEnumType } from './DirectionEnumType';
+
+export const orderInput = (name: string, sort: GraphQLEnumType) =>
+  new GraphQLInputObjectType({
+    name,
+    fields: () => ({
+      sort: {
+        type: new GraphQLNonNull(sort),
+      },
+      direction: {
+        type: new GraphQLNonNull(DirectionEnumType),
+      },
+    }),
+  });


### PR DESCRIPTION
## What

Promotes 6 GraphQL helpers from the Woovi monorepo's **unpublished** `@woovi/graphql` package into this published shared lib, so standalone services (e.g. service-invoice) can consume them instead of vendoring.

### Helpers added
| Helper | Monorepo origin |
|--------|-----------------|
| `conditionId` | `packages/graphql/src/conditionId.ts` |
| `graphqlEnumBuilder` (+ `enumBuilderValues`) | `packages/graphql/src/graphqlEnumBuilder.ts` |
| `buildSortFromOrderByArg` (+ `DIRECTION`, `OrderByArg` types) | `packages/graphql/src/order/buildSortFromOrderByArg.ts` |
| `orderByField` | `packages/graphql/src/order/orderByField.ts` |
| `orderByFilterField` | `packages/graphql/src/order/orderByFilterField.ts` |
| `orderInput` | `packages/graphql/src/order/orderInput.ts` |

All are re-exported from `src/index.ts`. Placed flat in `src/` to match the lib's layout.

## Import adaptations
Bodies are faithful copies. Adapted only:
- `orderByFilterField`: `FILTER_CONDITION_TYPE` now imported from local `./constants` (was `@woovi/graphql-mongo-helpers` self-import in the monorepo).
- `orderInput`: uses local `./DirectionEnumType`'s `DirectionEnumType` GraphQL enum (the monorepo imported `DirectionEnum` from `./DirectionEnum.ts`; here `DirectionEnum` is an SDL string and `DirectionEnumType` is the enum type).
- `orderByFilterField`: `buildSortFromOrderByArg` imported from the new sibling file.

### Minimal type-only tweaks (no runtime change)
Required by this repo's stricter `tsc` (dts generation) + `mongoose@9` types:
- `graphqlEnumBuilder`/`enumBuilderValues`: generic constrained to `<T extends EnumObject = EnumObject>` so string-indexing typechecks.
- `orderByFilterField`: `pipeline` param typed `OrderByArg<string>[]` (was implicit `any`).
- `conditionId`: added `!id ||` null guard so `mongoose@9`'s stricter `isValid` typechecks; behavior unchanged (null → `[]`).

## Deferred
`getDateFilter` was **not** included — it depends on `dateFilterCondition` from the unpublished `@woovi/utils`, which will be promoted to a different lib later.

## Validation
- `pnpm build` (rslib) passes, including dts generation.
- `pnpm vitest --run` passes: 45 tests (5 new in `src/__tests__/order.spec.ts` covering `conditionId`, `buildSortFromOrderByArg`, `orderByFilterField`, `orderInput`).

No version bump — release left to a maintainer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)