### PR TITLE
feat: add date-filter family (DateFilterInput, dateFilterCondition, getDateFilter)

### DIFF
--- a/src/DateFilterInputType.ts
+++ b/src/DateFilterInputType.ts
@@ -1,0 +1,44 @@
+import { GraphQLInputObjectType, GraphQLString } from 'graphql';
+
+export type DateFilterInputType = {
+  begin: string;
+  start: string;
+  end: string;
+};
+
+export type NormalizedDateFilterInputType = {
+  begin: string;
+  end: string;
+};
+
+export const DateFilterInput = new GraphQLInputObjectType({
+  name: 'DateFilter',
+  fields: () => ({
+    start: {
+      type: GraphQLString,
+      deprecationReason:
+        'using begin field instead of start to normalize fields',
+      description: 'start date',
+    },
+    begin: {
+      type: GraphQLString,
+      description: 'start date',
+    },
+    end: {
+      type: GraphQLString,
+      description: 'end date',
+    },
+  }),
+});
+
+export const getNormalizedDate = (
+  date: DateFilterInputType,
+): NormalizedDateFilterInputType => {
+  const begin = date?.start ? date?.start : date?.begin;
+  const end = date?.end;
+
+  return {
+    begin,
+    end,
+  };
+};

--- a/src/__tests__/dateFilter.spec.ts
+++ b/src/__tests__/dateFilter.spec.ts
@@ -1,0 +1,104 @@
+import { it, expect } from 'vitest';
+
+import { dateFilterCondition } from '../dateFilterCondition';
+import { getDateFilter } from '../getDateFilter';
+import { FILTER_CONDITION_TYPE } from '../constants';
+
+it('should return an empty object when date is null', () => {
+  const format = dateFilterCondition({ fieldFilter: 'createdAt' });
+  expect(format(null)).toEqual({});
+});
+
+it('should return an empty array when neither begin/start nor end is provided', () => {
+  const format = dateFilterCondition({ fieldFilter: 'createdAt' });
+  expect(format({ begin: '', start: '', end: '' })).toEqual([]);
+});
+
+it('should build a $gte condition from the begin field', () => {
+  const format = dateFilterCondition({ fieldFilter: 'createdAt' });
+  expect(
+    format({ begin: '2024-01-01T00:00:00.000Z', start: '', end: '' }),
+  ).toEqual({
+    createdAt: {
+      $gte: new Date('2024-01-01T00:00:00.000Z'),
+    },
+  });
+});
+
+it('should prefer the start field over begin for the $gte condition', () => {
+  const format = dateFilterCondition({ fieldFilter: 'createdAt' });
+  expect(
+    format({
+      begin: '2024-01-01T00:00:00.000Z',
+      start: '2024-02-01T00:00:00.000Z',
+      end: '',
+    }),
+  ).toEqual({
+    createdAt: {
+      $gte: new Date('2024-02-01T00:00:00.000Z'),
+    },
+  });
+});
+
+it('should build a $lte condition from the end field', () => {
+  const format = dateFilterCondition({ fieldFilter: 'createdAt' });
+  expect(
+    format({ begin: '', start: '', end: '2024-01-31T23:59:59.999Z' }),
+  ).toEqual({
+    createdAt: {
+      $lte: new Date('2024-01-31T23:59:59.999Z'),
+    },
+  });
+});
+
+it('should build both $gte and $lte conditions', () => {
+  const format = dateFilterCondition({ fieldFilter: 'createdAt' });
+  expect(
+    format({
+      begin: '2024-01-01T00:00:00.000Z',
+      start: '',
+      end: '2024-01-31T23:59:59.999Z',
+    }),
+  ).toEqual({
+    createdAt: {
+      $gte: new Date('2024-01-01T00:00:00.000Z'),
+      $lte: new Date('2024-01-31T23:59:59.999Z'),
+    },
+  });
+});
+
+it('should merge extra conditions into the built condition', () => {
+  const format = dateFilterCondition({
+    fieldFilter: 'createdAt',
+    conditions: { status: 'ACTIVE' },
+  });
+  expect(
+    format({ begin: '2024-01-01T00:00:00.000Z', start: '', end: '' }),
+  ).toEqual({
+    createdAt: {
+      $gte: new Date('2024-01-01T00:00:00.000Z'),
+    },
+    status: 'ACTIVE',
+  });
+});
+
+it('should wrap dateFilterCondition into a CUSTOM_CONDITION filter mapping', () => {
+  const filter = getDateFilter({
+    filterName: 'createdAtRange',
+    fieldFilter: 'createdAt',
+  });
+  expect(filter.createdAtRange.type).toBe(
+    FILTER_CONDITION_TYPE.CUSTOM_CONDITION,
+  );
+  expect(
+    filter.createdAtRange.format({
+      begin: '2024-01-01T00:00:00.000Z',
+      start: '',
+      end: '',
+    }),
+  ).toEqual({
+    createdAt: {
+      $gte: new Date('2024-01-01T00:00:00.000Z'),
+    },
+  });
+});

--- a/src/dateFilterCondition.ts
+++ b/src/dateFilterCondition.ts
@@ -1,0 +1,35 @@
+import type { DateFilterInputType } from './DateFilterInputType';
+import { getNormalizedDate } from './DateFilterInputType';
+
+type DateFilterPipeline = {
+  fieldFilter: string;
+  conditions?: Record<string, any>;
+};
+
+export const dateFilterCondition =
+  ({ fieldFilter, conditions = {} }: DateFilterPipeline) =>
+  (date: DateFilterInputType | null) => {
+    if (date != null) {
+      const { begin } = getNormalizedDate(date);
+
+      if (!begin && !date.end) {
+        return [];
+      }
+
+      const beginCondition = begin ? { $gte: new Date(begin) } : {};
+
+      const endCondition = date.end ? { $lte: new Date(date.end) } : {};
+
+      const condition = {
+        [fieldFilter]: {
+          ...beginCondition,
+          ...endCondition,
+        },
+        ...conditions,
+      };
+
+      return condition;
+    }
+
+    return {};
+  };

--- a/src/getDateFilter.ts
+++ b/src/getDateFilter.ts
@@ -1,0 +1,25 @@
+import { FILTER_CONDITION_TYPE } from './constants';
+import { dateFilterCondition } from './dateFilterCondition';
+
+type DateFilterPipeline = {
+  filterName: string;
+  fieldFilter: string;
+  fieldProject?: string;
+  projectFields?: Record<string, unknown>;
+  useTimezone?: boolean;
+  conditions?: Record<string, unknown>;
+};
+
+export const getDateFilter = ({
+  fieldFilter,
+  filterName,
+  conditions = {},
+}: DateFilterPipeline) => ({
+  [filterName]: {
+    type: FILTER_CONDITION_TYPE.CUSTOM_CONDITION,
+    format: dateFilterCondition({
+      fieldFilter,
+      conditions,
+    }),
+  },
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -44,3 +44,11 @@ export {
   registerTypeLoader,
   typeResolver,
 } from './typeRegistry.ts';
+export {
+  DateFilterInput,
+  getNormalizedDate,
+  type DateFilterInputType,
+  type NormalizedDateFilterInputType,
+} from './DateFilterInputType';
+export { dateFilterCondition } from './dateFilterCondition';
+export { getDateFilter } from './getDateFilter';


### PR DESCRIPTION
## What

Promotes the date-filter helpers currently vendored in `service-invoice` into this published lib, so they resolve fully in-tree (they were the last deferred piece — `getDateFilter` previously reached into unpublished `@woovi/graphql`/`@woovi/utils`).

Added to `src/` (flat, matching lib convention):

- **`DateFilterInputType.ts`** — `DateFilterInput` (GraphQL input type) + `getNormalizedDate` + types `DateFilterInputType` / `NormalizedDateFilterInputType`. Faithful copy from `@woovi/utils` (imports only `graphql`).
- **`dateFilterCondition.ts`** — from `@woovi/utils`. **`moment` replaced with native `Date`**: `moment.utc(x).toDate()` → `new Date(x)`, preserving the exact `$gte`/`$lte` semantics. Imports `getNormalizedDate` from the new sibling.
- **`getDateFilter.ts`** — from `@woovi/graphql`. Imports adapted: `FILTER_CONDITION_TYPE` from `./constants` (local), `dateFilterCondition` from `./dateFilterCondition` (new sibling).

All barrel-exported from `src/index.ts`. Added `src/__tests__/dateFilter.spec.ts` covering the `$gte`/`$lte` cases across begin/start/end, extra-conditions merge, and the `getDateFilter` mapping.

## moment → Date

`moment.utc(str).toDate()` parses the string and returns a native `Date`. `new Date(str)` produces the identical instant for ISO-8601 strings carrying a `Z`/offset (the shape the frontend sends) and for date-only strings (ES spec parses those as UTC). No new runtime dependency — `moment` dropped, `graphql` was already a peer/dev dep.

## Testing

- `pnpm build` (rslib esm+cjs+dts, strict) — passes
- `pnpm vitest --run` — 53 passed (8 new), no type tightenings needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)