### PR TITLE
chore: release 5.0.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@woovi/graphql-mongo-helpers",
   "description": "Mongo helpers to be used when building a GraphQL API",
-  "version": "5.0.2",
+  "version": "5.0.3",
   "author": {
     "name": "Entria",
     "email": "dev@woovi.com",


### PR DESCRIPTION
Version bump 5.0.2 → 5.0.3 para publicar uma versão que carrega os helpers promovidos do monorepo @woovi/graphql:
- #766 (order/enum: conditionId, graphqlEnumBuilder, buildSortFromOrderByArg, orderByField, orderByFilterField, orderInput)
- #767 (date-filter: DateFilterInput, getNormalizedDate, dateFilterCondition, getDateFilter)

Sem mudança de código (já está na main); só o bump de versão. Publish no npm é manual (`pnpm publish`, 2FA) — não há CI de publish neste repo.